### PR TITLE
Fixed a typo in one of the patch files and removed union wait.

### DIFF
--- a/dependencies/MiniSat/nusmv.patch
+++ b/dependencies/MiniSat/nusmv.patch
@@ -564,7 +564,7 @@ diff -Naur minisat.ORIG/simp/Solver_C.C minisat/simp/Solver_C.C
 +  return (MiniSat_ptr)new SimpSolver();
 +}
 +
-+extern "C"void MiniSat_Delete(MiniSat_ptr ms)
++extern "C" void MiniSat_Delete(MiniSat_ptr ms)
 +{
 +  delete (SimpSolver *)ms;
 +}

--- a/dependencies/NuSMV/cudd.patch
+++ b/dependencies/NuSMV/cudd.patch
@@ -425,3 +425,18 @@
  CFLAGS  = $(ICFLAGS) $(MFLAG) $(XCFLAGS)
  
  LINTFLAGS = -u -n
+--- NuSMV-2.5.4/cudd-2.4.1.1/util/pipefork.c	2011-10-12 11:05:29.000000000 +0200
++++ CUDD/util/pipefork.c 2016-12-16 10:48:56.000000000 +0100
+@@ -39,12 +39,7 @@ int util_pipefork(char **argv,		/* normal argv argument list */
+     int forkpid, waitPid;
+     int topipe[2], frompipe[2];
+     char buffer[1024];
+-
+-#if (defined __hpux) || (defined __osf__) || (defined _IBMR2) || (defined __SVR4) || (defined __CYGWIN32__) || (defined __MINGW32__) 
+     int status;
+-#else
+-    union wait status;
+-#endif
+ 
+     /* create the PIPES...
+      * fildes[0] for reading from command


### PR DESCRIPTION
I wasn't able to build nor install the library because 2 problems arised.
I faced these problems when compiling NuSMV 2.6.0 as well, so I basically just applied the same patches to these patch files.

For some reason, union wait doesn't seem to exist (seems to be BSD specific) and since it was removed in CUDD 2.5.0, I decided to remove it and it successfully passed all tests.